### PR TITLE
Add conversation log to PR descriptions

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -10,7 +10,7 @@
   - **Problem**: succinct description of the issue — include expected vs. actual behavior when applicable
   - **Solution**: *why* this approach was chosen, key trade-offs considered, and overall description of the changes
   - **Testing**: describe what was done to verify the fix — automated (new/updated tests, CI steps) or manual (commands run, actions taken locally). Write in prose or concise paragraphs, not an incomplete checklist
-- At the end of every PR description, append collapsible sections for context:
+- At the end of every PR description, append a `## Prompts` heading with collapsible sections for context:
   1. **Plan section** (only when a plan was generated during the session): a `<details><summary>Plan</summary>` block containing the **final** plan (not intermediate drafts)
   2. **Conversation section**: a `<details><summary>Conversation</summary>` block containing the task-relevant conversation (not the entire session — only the portion relevant to the PR's changes)
      - User messages formatted as block quotes (`>`)

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -10,6 +10,12 @@
   - **Problem**: succinct description of the issue — include expected vs. actual behavior when applicable
   - **Solution**: *why* this approach was chosen, key trade-offs considered, and overall description of the changes
   - **Testing**: describe what was done to verify the fix — automated (new/updated tests, CI steps) or manual (commands run, actions taken locally). Write in prose or concise paragraphs, not an incomplete checklist
+- At the end of every PR description, append collapsible sections for context:
+  1. **Plan section** (only when a plan was generated during the session): a `<details><summary>Plan</summary>` block containing the **final** plan (not intermediate drafts)
+  2. **Conversation section**: a `<details><summary>Conversation</summary>` block containing the task-relevant conversation (not the entire session — only the portion relevant to the PR's changes)
+     - User messages formatted as block quotes (`>`)
+     - Claude replies formatted as code blocks (triple backticks)
+  3. When both sections are present, the Plan section comes first
 
 ## Planning
 - Always ask clarifying questions before finalizing a plan


### PR DESCRIPTION
## Context

When reviewing PRs created with Claude Code, future readers often lack context on the decisions made during the session — why a particular approach was chosen, what alternatives were discussed, etc.

## Problem

PR descriptions capture the *what* and *why* of changes, but not the back-and-forth that led to those decisions. This context is lost once the Claude Code session ends.

## Solution

Added instructions to CLAUDE.md requiring every PR description to end with a `## Prompts` heading containing collapsible `<details>` sections:

1. A **Plan** section (when a plan was generated) containing the final plan
2. A **Conversation** section with the task-relevant dialogue (user messages as block quotes, Claude replies as code blocks)

Using collapsible sections keeps the main PR body clean while making full context available on demand. Only the task-relevant portion of the conversation is included — not the entire session — to keep signal-to-noise high.

## Testing

Verified the updated CLAUDE.md reads correctly and the new bullet integrates naturally into the existing PR Creation section.

## Prompts

<details><summary>Plan</summary>

## Plan: Add conversation log to PR descriptions

### Context
The user wants future PR descriptions to include the task-relevant conversation between them and Claude Code, so future readers have full context on the decisions made. When a plan was generated, it should also be included in its own collapsible section before the conversation.

### Changes

**File:** `claude/.claude/CLAUDE.md`

Add a new bullet to `## PR Creation` with instructions to append collapsible sections at the end of every PR description:

1. **Plan section** (only when a plan was generated): a `<details><summary>Plan</summary>` block containing the **final** plan (not intermediate drafts)
2. **Conversation section**: a `<details><summary>Conversation</summary>` block containing the task-relevant conversation, with:
   - User inputs formatted as block quotes (`>`)
   - Claude replies formatted as code blocks (triple backticks)
3. Plan section comes before conversation section when both are present
4. Only include the task-relevant portion of the conversation (not the entire session)

</details>

<details><summary>Conversation</summary>

> Implement the following plan:
> [plan as above]

```
Read CLAUDE.md, edited to add the new bullet under PR Creation,
created branch an--pr-conversation-log, committed and pushed.
```

> The new sections should be under a new heading called "Prompts"

```
Updated the instruction to read: append a ## Prompts heading
with the collapsible sections nested underneath it.
Committed and pushed.
```

> Update the PR description

```
[Updating PR description to match the new Prompts heading convention]
```

</details>